### PR TITLE
readme: Replace newgrp with su

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,8 +50,7 @@ usermod -a -G libvirt <user>
 This group update will take effect the next time the user logs in.
 Alternatively, the user can update a shell session with:
 ```bash
-exec newgrp libvirt
-exec newgrp
+su $USER
 ```
 
 ## Create and start the VM


### PR DESCRIPTION
Unfortunately, the second newgrp command resets all groups but doesn't keep the libvirt one.

Cc @nbouchinet-anssi